### PR TITLE
Bug/94/develop/docker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
 				"@typescript-eslint/parser": "^2.10.0",
 				"aws-sdk": "^2.842.0",
 				"camelcase": "^5.3.1",
-				"canvas": "^2.7.0",
 				"case-sensitive-paths-webpack-plugin": "2.3.0",
 				"chart.js": "^2.9.4",
 				"classnames": "^2.3.1",
@@ -7029,20 +7028,6 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
 			"integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg=="
 		},
-		"node_modules/canvas": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/canvas/-/canvas-2.7.0.tgz",
-			"integrity": "sha512-pzCxtkHb+5su5MQjTtepMDlIOtaXo277x0C0u3nMOxtkhTyQ+h2yNKhlROAaDllWgRyePAUitC08sXw26Eb6aw==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"nan": "^2.14.0",
-				"node-pre-gyp": "^0.15.0",
-				"simple-get": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -8438,17 +8423,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"engines": {
 				"node": ">=0.10"
-			}
-		},
-		"node_modules/decompress-response": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-			"dependencies": {
-				"mimic-response": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/dedent": {
@@ -16286,14 +16260,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -16621,7 +16587,8 @@
 		"node_modules/nan": {
 			"version": "2.14.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.1.20",
@@ -27222,21 +27189,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-		},
-		"node_modules/simple-get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"dependencies": {
-				"decompress-response": "^4.2.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
 		"node_modules/simple-swizzle": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -36590,16 +36542,6 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
 			"integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg=="
 		},
-		"canvas": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/canvas/-/canvas-2.7.0.tgz",
-			"integrity": "sha512-pzCxtkHb+5su5MQjTtepMDlIOtaXo277x0C0u3nMOxtkhTyQ+h2yNKhlROAaDllWgRyePAUitC08sXw26Eb6aw==",
-			"requires": {
-				"nan": "^2.14.0",
-				"node-pre-gyp": "^0.15.0",
-				"simple-get": "^3.0.3"
-			}
-		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -37763,14 +37705,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-		},
-		"decompress-response": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-			"requires": {
-				"mimic-response": "^2.0.0"
-			}
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -44237,11 +44171,6 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
-		"mimic-response": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-		},
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -44521,7 +44450,8 @@
 		"nan": {
 			"version": "2.14.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+			"optional": true
 		},
 		"nanoid": {
 			"version": "3.1.20",
@@ -53254,21 +53184,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-		},
-		"simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-		},
-		"simple-get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"requires": {
-				"decompress-response": "^4.2.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"@typescript-eslint/parser": "^2.10.0",
 		"aws-sdk": "^2.842.0",
 		"camelcase": "^5.3.1",
-		"canvas": "^2.7.0",
 		"case-sensitive-paths-webpack-plugin": "2.3.0",
 		"chart.js": "^2.9.4",
 		"classnames": "^2.3.1",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+import 'jest-canvas-mock';


### PR DESCRIPTION
### Deprecations *(optional)*
Uninstall canvas

### Enhancements *(optional but at least, you should write either New Features or Enhancement)*
On branch 88, I installed 'canvas' because of the error message as an attached file.
However, a Docker error showed up.
The reason was that 'node-alpine' uses 'musl', on the other hand, 'canvas' uses glibc.
So, I uninstalled canvas and added jest-canvas-mock on the setup file to solve this issue.

## Screenshots
<img width="928" alt="Screenshot 2021-04-27 at 07 29 02" src="https://user-images.githubusercontent.com/78789212/116193016-fbd05200-a72e-11eb-8046-19ba424698e4.png">


## Checklist
- [x] Run automated tests

Resolves #94 
