### PR TITLE
Add a media query for a larger screen

### DIFF
--- a/src/components/PositionCard.css
+++ b/src/components/PositionCard.css
@@ -19,6 +19,11 @@
 		padding: 16px;
 	}
 }
+@media screen and (min-width: 992px) {
+	.position-card {
+		width: auto;
+	}
+}
 
 .position-card-title {
 	font-family: 'protipo', sans-serif;


### PR DESCRIPTION
### Enhancements *(optional but at least, you should write either New Features or Enhancement)*
When the screen size is 992px and bigger, the position screen size will be change by calculating the sidebar.
## Screenshots
- iPhone X
<img width="324" alt="Screenshot 2021-04-27 at 08 59 28" src="https://user-images.githubusercontent.com/78789212/116199082-055db800-a737-11eb-929a-c7d7785a2405.png">

-larger
<img width="1101" alt="Screenshot 2021-04-27 at 08 59 17" src="https://user-images.githubusercontent.com/78789212/116199102-0989d580-a737-11eb-8d65-e00d43454d52.png">

## Checklist
- [x] Run automated tests
- [x] Looks good on the window that has 320px height
- [x] Looks good on the window that has 360px height

Resolves #96 
