### PR TITLE
bug/135/searchbar/doubleclick

### DIFF
--- a/src/pages/Search/SearchScreen/SearchScreen.tsx
+++ b/src/pages/Search/SearchScreen/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import { IonApp, IonContent, IonHeader, IonList, IonSearchbar } from '@ionic/react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import SearchResults from '../../../components/SearchResults/SearchResults';
 import './SearchScreen.css';
 
@@ -7,6 +7,10 @@ const SearchScreen: React.FC = () => {
 	const [searchText, setsearchText] = useState<string>();
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const [searchResults, setSearchResults] = useState<Array<any>>([]);
+
+	useEffect(() => {
+		document.querySelector('input')?.focus();
+	}, []);
 	return (
 		<IonApp>
 			<IonHeader className="search-screen-header">


### PR DESCRIPTION
### Enhancements *(optional but at least, you should write either New Features or Enhancement)*
Set a search bar clicked.
A user doesn't need to click the search bar again.

## Screenshots
![Screenshot 2021-06-21 at 17 57 52](https://user-images.githubusercontent.com/78789212/122792214-3df2bb80-d2ba-11eb-8ec0-2960f052d815.png)

## Checklist
- [x] Run automated tests
- [x] Looks good on the window that has 320px height
- [x] Looks good on the window that has 360px height

Resolves #135 
