### PR TITLE
Feature/207/position screen/hide dummy data

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -92,7 +92,7 @@ export type PartyMatchType = {
 
 export type Position = {
 	title: string;
-	answer: string|undefined;
+	answer: string | undefined;
 	reason: string;
 };
 /* export type Bio = {

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -92,7 +92,7 @@ export type PartyMatchType = {
 
 export type Position = {
 	title: string;
-	answer: string;
+	answer: string|undefined;
 	reason: string;
 };
 /* export type Bio = {

--- a/src/components/PopupCard/PositionPopup/PositionPopup.tsx
+++ b/src/components/PopupCard/PositionPopup/PositionPopup.tsx
@@ -6,7 +6,7 @@ import './PositionPopup.css';
 
 interface PositionPopupProps {
 	title: string;
-	positioning: string|undefined;
+	positioning: string | undefined;
 	reason: string;
 }
 const PositionPopup: React.FC<PositionPopupProps> = (props: PositionPopupProps) => (

--- a/src/components/PopupCard/PositionPopup/PositionPopup.tsx
+++ b/src/components/PopupCard/PositionPopup/PositionPopup.tsx
@@ -6,7 +6,7 @@ import './PositionPopup.css';
 
 interface PositionPopupProps {
 	title: string;
-	positioning: string;
+	positioning: string|undefined;
 	reason: string;
 }
 const PositionPopup: React.FC<PositionPopupProps> = (props: PositionPopupProps) => (

--- a/src/components/PositionCards/PositionCard/PositionCard.tsx
+++ b/src/components/PositionCards/PositionCard/PositionCard.tsx
@@ -9,7 +9,7 @@ import PositionPopup from '../../PopupCard/PositionPopup/PositionPopup';
 interface PostionCardProps {
 	candidateId: number;
 	title: string;
-	answer: string;
+	answer: string|undefined;
 	reason: string;
 }
 
@@ -30,7 +30,10 @@ const PositionCard: React.FC<PostionCardProps> = (props: PostionCardProps) => {
 						</div>
 						<div className="position-card-sub-content">
 							<div className="position-positioning">
-								<Positioning positioning={props.answer} />
+								{
+									props.answer === undefined? undefined:	<Positioning positioning={props.answer} />
+								}
+								
 							</div>
 							<IonIcon slot="icon-only" icon={chevronForwardOutline} />
 						</div>

--- a/src/components/PositionCards/PositionCard/PositionCard.tsx
+++ b/src/components/PositionCards/PositionCard/PositionCard.tsx
@@ -9,7 +9,7 @@ import PositionPopup from '../../PopupCard/PositionPopup/PositionPopup';
 interface PostionCardProps {
 	candidateId: number;
 	title: string;
-	answer: string|undefined;
+	answer: string | undefined;
 	reason: string;
 }
 
@@ -30,10 +30,9 @@ const PositionCard: React.FC<PostionCardProps> = (props: PostionCardProps) => {
 						</div>
 						<div className="position-card-sub-content">
 							<div className="position-positioning">
-								{
-									props.answer === undefined? undefined:	<Positioning positioning={props.answer} />
-								}
-								
+								{props.answer === undefined ? undefined : (
+									<Positioning positioning={props.answer} />
+								)}
 							</div>
 							<IonIcon slot="icon-only" icon={chevronForwardOutline} />
 						</div>

--- a/src/components/PositionCards/Positioning/Positioning.tsx
+++ b/src/components/PositionCards/Positioning/Positioning.tsx
@@ -3,7 +3,7 @@ import { germanTranslator } from '../../../functions/germanTranslator';
 import './Positioning.css';
 
 interface PositioningProps {
-	positioning: string|undefined;
+	positioning: string | undefined;
 }
 
 const Positioning: React.FC<PositioningProps> = ({ positioning }: PositioningProps) => {

--- a/src/components/PositionCards/Positioning/Positioning.tsx
+++ b/src/components/PositionCards/Positioning/Positioning.tsx
@@ -3,7 +3,7 @@ import { germanTranslator } from '../../../functions/germanTranslator';
 import './Positioning.css';
 
 interface PositioningProps {
-	positioning: string;
+	positioning: string|undefined;
 }
 
 const Positioning: React.FC<PositioningProps> = ({ positioning }: PositioningProps) => {

--- a/src/functions/germanTranslator.ts
+++ b/src/functions/germanTranslator.ts
@@ -1,4 +1,4 @@
-export const germanTranslator = (word: string): string|undefined => {
+export const germanTranslator = (word: string|undefined): string|undefined => {
 	let translated: string|undefined;
 	switch (word) {
 	case 'yes':

--- a/src/pages/Position.tsx
+++ b/src/pages/Position.tsx
@@ -6,57 +6,58 @@ import fetch from '../functions/queries';
 import MobileScreen from '../hoc/MobileScreen';
 const reason =
 	'"Das ist nur ein Platzhalter. Für die Bundestagswahl haben Kandidat:innen  hier die Möglichkeit ihre Position zu begründen"';
+const answer = undefined
 const examplePositionData = [
 	{
 		title: 'Pfleger:innen aus dem Ausland',
-		answer: 'yes',
+		answer: answer,
 		reason: reason,
 	},
 	{
 		title: 'Lobbyismusgesetz verschärfen',
-		answer: 'no',
+		answer: 'answer',
 		reason: reason,
 	},
 	{
 		title: 'Abitur aussetzen',
-		answer: 'yes',
+		answer: 'answer',
 		reason: reason,
 	},
 	{
 		title: 'Bedigungsloses Grundeinkommen',
-		answer: 'no',
+		answer: 'answer',
 
 		reason: reason,
 	},
 	{
 		title: 'Spitzensteuersatz senken',
-		answer: 'yes',
+		answer: 'answer',
 		reason: reason,
 	},
 	{
 		title: 'Mehr Subventionen für erneuerbare Energien',
-		answer: 'no',
+		answer: 'answer',
 
 		reason: reason,
 	},
 	{
 		title: 'Mehr Geld für Pflegekräfte',
-		answer: 'yes',
+		answer: 'answer',
 		reason: reason,
 	},
 	{
 		title: 'Soziale Start-ups fördern',
-		answer: 'yes',
+		answer: 'answer',
 		reason: reason,
 	},
 	{
 		title: 'Amazon und Co. angemessen besteuern',
-		answer: 'yes',
+		answer: 'answer',
 		reason: reason,
 	},
 	{
 		title: 'Mietpreise deckeln',
-		answer: 'no',
+		answer: 'answer',
 
 		reason: reason,
 	},

--- a/src/pages/Position.tsx
+++ b/src/pages/Position.tsx
@@ -6,7 +6,7 @@ import fetch from '../functions/queries';
 import MobileScreen from '../hoc/MobileScreen';
 const reason =
 	'"Das ist nur ein Platzhalter. Für die Bundestagswahl haben Kandidat:innen  hier die Möglichkeit ihre Position zu begründen"';
-const answer = undefined
+const answer = undefined;
 const examplePositionData = [
 	{
 		title: 'Pfleger:innen aus dem Ausland',


### PR DESCRIPTION
### Enhancements *(optional but at least, you should write either New Features or Enhancement)*
Removed politician's dummy positionings

## Screenshots
![Screenshot 2021-07-23 at 17 15 25](https://user-images.githubusercontent.com/78789212/126803367-ee837793-a41d-4180-ab39-9a9bd7cb908c.png)

## Checklist
- [x] Run automated tests
- [x] Looks good on the window that has 320px height
- [x] Looks good on the window that has 360px height

Resolves #207 
